### PR TITLE
fix: specify encoding 

### DIFF
--- a/tvvn.py
+++ b/tvvn.py
@@ -34,7 +34,7 @@ home = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('path'))
 fanart = xbmc.translatePath(os.path.join(home, 'fanart.jpg'))
 datafile = xbmc.translatePath(os.path.join(home, 'data.json'))
 
-data = json.loads(open(datafile,"r").read())
+data = json.loads(open(datafile,"r",encoding="utf8").read())
 
 mode=None
 


### PR DESCRIPTION
On Kodi 19.0.0 Matrix, not specifying the encoding of the `data.json` file leads to the following exception thrown: 

```
<general>: EXCEPTION Thrown (PythonToCppException) : 
-->Python callback/script returned the following error<--
- NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
	Error Type: <class 'UnicodeDecodeError'>
	Error Contents: 'charmap' codec can't decode byte 0x81 in position 1814: character maps to <undefined>
	
	Traceback (most recent call last):
	File "C:\Users\lekev\AppData\Roaming\Kodi\addons\plugin.video.tvvn\tvvn.py", line 37, in <module>
	
	data = json.loads(open(datafile,"r").read())
	
	File "C:\Program Files\Kodi\system\python\Lib\encodings\cp1252.py", line 23, in decode
	return codecs.charmap_decode(input,self.errors,decoding_table)[0]
	
	UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 1814: character maps to <undefined>
-->End of Python script error report<--
```

By specifying the encoding it allows the file to be read properly. 

Tested with Kodi Matrix 19.0.0 running on Google TV with Chromecast (2020 Android 10 4.9.180) and Windows 10 (v2004 19041.867).